### PR TITLE
singleBranch to default to false from create from marketplace

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/marketplace/internal/MarketplaceServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/marketplace/internal/MarketplaceServiceInternalImpl.java
@@ -486,6 +486,9 @@ public class MarketplaceServiceInternalImpl implements MarketplaceService, Initi
 		createFromRemoteRequest.setRemoteName(request.getRemoteName());
 		createFromRemoteRequest.setRemoteBranch(plugin.getRef());
 		createFromRemoteRequest.setAuthentication(NONE);
+		// The remoteBranch is set to the plugin ref, which actually seems to be a tag. That would
+		// fail since there is no branch like refs/heads/<tag>. So we are cloning all branches (which will bring the tags as well)
+		createFromRemoteRequest.setSingleBranch(false);
 		return createFromRemoteRequest;
 	}
 


### PR DESCRIPTION
singleBranch to default to false from create from marketplace
Related to https://github.com/craftercms/craftercms/issues/6061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-branch cloning is now available for marketplace-provided sites during site creation, enabling access to multiple repository branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->