### PR TITLE
Add savedAsDraft to ContentItem

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -9942,6 +9942,9 @@ components:
                     type: integer
                     format: int32
                     description: number of children of the item
+                savedAsDraft:
+                    type: boolean
+                    description: true if item is saved as draft, otherwise false
                 staging:
                     $ref: '#/components/schemas/PublishTargetStatus'
                     description: status of the item in the staging target

--- a/src/main/java/org/craftercms/studio/api/v1/constant/StudioXmlConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v1/constant/StudioXmlConstants.java
@@ -29,6 +29,7 @@ public final class StudioXmlConstants {
 	public static final String DOCUMENT_ELM_CONTENT_TYPE = "content-type";
 	public static final String DOCUMENT_ELM_FILE_NAME = "file-name";
 	public static final String DOCUMENT_ELM_DISABLED = "disabled";
+	public static final String DOCUMENT_ELM_SAVED_AS_DRAFT = "savedAsDraft";
 
 	/**
 	 * xml document root and element names for roles-mapping and permissions-mapping xmls

--- a/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
@@ -58,6 +58,7 @@ public class Item {
 	private int ignoredAsInt;
 	private boolean ignored;
 	private int childrenCount = 0;
+	private Boolean savedAsDraft;
 
 	public Item() {
 	}
@@ -91,6 +92,7 @@ public class Item {
 		ignoredAsInt = builder.ignoredAsInt;
 		ignored = builder.ignored;
 		childrenCount = builder.childrenCount;
+		savedAsDraft = builder.savedAsDraft;
 	}
 
 	public long getId() {
@@ -317,6 +319,14 @@ public class Item {
 		this.childrenCount = childrenCount;
 	}
 
+	public Boolean getSavedAsDraft() {
+		return savedAsDraft;
+	}
+
+	public void setSavedAsDraft(Boolean savedAsDraft) {
+		this.savedAsDraft = savedAsDraft;
+	}
+
 	public static final class Builder {
 		private long id;
 		private long siteId;
@@ -346,6 +356,7 @@ public class Item {
 		private int ignoredAsInt;
 		private boolean ignored;
 		private int childrenCount = 0;
+		private Boolean savedAsDraft;
 
 		public Builder() {
 		}
@@ -379,6 +390,7 @@ public class Item {
 			clone.ignoredAsInt = item.ignoredAsInt;
 			clone.ignored = item.ignored;
 			clone.childrenCount = item.childrenCount;
+			clone.savedAsDraft = item.savedAsDraft;
 			return clone;
 		}
 
@@ -511,6 +523,11 @@ public class Item {
 
 		public Builder withAvailableActions(long availableActions) {
 			this.availableActions = availableActions;
+			return this;
+		}
+
+		public Builder withSavedAsDraft(Boolean savedAsDraft) {
+			this.savedAsDraft = savedAsDraft;
 			return this;
 		}
 

--- a/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
@@ -621,7 +621,7 @@ public interface ItemDAO {
 							   @Param(LAST_MODIFIED_BY) long lastModifiedBy, @Param(LAST_MODIFIED_ON) String lastModifiedOn,
 							   @Param(LABEL) String label, @Param(CONTENT_TYPE_ID) String contentTypeId,
 							   @Param(SYSTEM_TYPE) String systemType, @Param(MIME_TYPE) String mimeType, @Param(SIZE) long size,
-							   @Param(IGNORED) boolean ignored);
+							   @Param(IGNORED) boolean ignored, @Param(SAVED_AS_DRAFT) boolean savedAsDraft);
 
 	/**
 	 * Update the path for all the affected folder items to reflect the move operation

--- a/src/main/java/org/craftercms/studio/api/v2/dal/QueryParameterNames.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/QueryParameterNames.java
@@ -254,6 +254,8 @@ public final class QueryParameterNames {
 
 	public static final String IGNORED = "ignored";
 
+	public static final String SAVED_AS_DRAFT = "savedAsDraft";
+
 	public static final String REMOVE_PAGE_PARENT_FOLDER = "removePageParentFolder";
 
 	/**

--- a/src/main/java/org/craftercms/studio/api/v2/dal/item/ContentItem.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/item/ContentItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -40,6 +40,7 @@ public class ContentItem {
 	private ZonedDateTime dateModified;
 	private long availableActions;
 	private int childrenCount;
+	private Boolean savedAsDraft;
 
 	private PublishTargetStatus staging;
 	private PublishTargetStatus live;
@@ -202,5 +203,13 @@ public class ContentItem {
 
 	public void setStaging(PublishTargetStatus staging) {
 		this.staging = staging;
+	}
+
+	public Boolean getSavedAsDraft() {
+		return savedAsDraft;
+	}
+
+	public void setSavedAsDraft(Boolean savedAsDraft) {
+		this.savedAsDraft = savedAsDraft;
 	}
 }

--- a/src/main/java/org/craftercms/studio/api/v2/service/item/ItemService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/item/ItemService.java
@@ -95,12 +95,11 @@ public interface ItemService {
 	 *
 	 * @param siteId   site identifier
 	 * @param path     path of the content
-	 * @param unlock   Indicates if content needs to be unlocked after write (save &amp; close)
 	 * @param parentId id of parent item
 	 * @throws ServiceLayerException if there is an error persisting the item
 	 * @throws UserNotFoundException if the user is not found
 	 */
-	void persistItemAfterCreate(String siteId, String path, boolean unlock, Long parentId)
+	void persistItemAfterCreate(String siteId, String path, Long parentId)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException;
 
 	/**
@@ -108,9 +107,8 @@ public interface ItemService {
 	 *
 	 * @param siteId site identifier
 	 * @param path   path of the content
-	 * @param unlock Indicates if content needs to be unlocked after write (save &amp; close)
 	 */
-	void persistItemAfterWrite(String siteId, String path, boolean unlock) throws ServiceLayerException, UserNotFoundException, AuthenticationException;
+	void persistItemAfterWrite(String siteId, String path) throws ServiceLayerException, UserNotFoundException, AuthenticationException;
 
 	/**
 	 * Persist item metadata after create folder

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -34,7 +34,6 @@ import org.craftercms.commons.security.exception.ActionDeniedException;
 import org.craftercms.commons.security.permissions.PermissionEvaluator;
 import org.craftercms.core.exception.PathNotFoundException;
 import org.craftercms.studio.api.v1.constant.DmConstants;
-import org.craftercms.studio.api.v1.constant.StudioXmlConstants;
 import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
@@ -137,6 +136,7 @@ import static org.apache.commons.lang3.Strings.CS;
 import static org.craftercms.studio.api.v1.constant.DmConstants.*;
 import static org.craftercms.studio.api.v1.constant.DmXmlConstants.*;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.*;
+import static org.craftercms.studio.api.v1.constant.StudioXmlConstants.*;
 import static org.craftercms.studio.api.v2.content.LifecycleContent.LifecycleOperation.*;
 import static org.craftercms.studio.api.v2.content.LifecycleContentProvider.ofPath;
 import static org.craftercms.studio.api.v2.content.LifecycleContentProvider.ofStream;
@@ -932,17 +932,19 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		String label = FilenameUtils.getName(path);
 		String contentTypeId = EMPTY;
 		boolean disabled = false;
+		boolean savedAsDraft = false;
 		if (CS.endsWith(path, XML_PATTERN)) {
 			try {
 				Document contentDoc = ContentUtils.convertStreamToXml(getContent(site.getSiteId(), path));
 				if (contentDoc != null) {
 					Element rootElement = contentDoc.getRootElement();
-					String internalName = rootElement.valueOf(StudioXmlConstants.DOCUMENT_ELM_INTERNAL_TITLE);
+					String internalName = rootElement.valueOf(DOCUMENT_ELM_INTERNAL_TITLE);
 					if (isNotEmpty(internalName)) {
 						label = internalName;
 					}
-					contentTypeId = rootElement.valueOf(StudioXmlConstants.DOCUMENT_ELM_CONTENT_TYPE);
-					disabled = Boolean.parseBoolean(rootElement.valueOf(StudioXmlConstants.DOCUMENT_ELM_DISABLED));
+					contentTypeId = rootElement.valueOf(DOCUMENT_ELM_CONTENT_TYPE);
+					disabled = Boolean.parseBoolean(rootElement.valueOf(DOCUMENT_ELM_DISABLED));
+					savedAsDraft = Boolean.parseBoolean(rootElement.valueOf(DOCUMENT_ELM_SAVED_AS_DRAFT));
 				}
 			} catch (DocumentException | ContentNotFoundException e) {
 				logger.error("Failed to extract metadata from XML file at site '{}' path '{}'",
@@ -976,6 +978,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 					.withLocaleCode(Locale.US.toString())
 					.withTranslationSourceId(null)
 					.withSize(contentRepository.getContentSize(site.getSiteId(), path))
+					.withSavedAsDraft(savedAsDraft)
 					.build();
 			itemDao.upsertEntry(item);
 
@@ -1478,12 +1481,12 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 			boolean isPage = isPageDescriptor(path);
 			String parentItemPath = getParentUrl(path);
 			Item parent = itemService.getItem(siteId, parentItemPath, isPage);
-			itemService.persistItemAfterCreate(siteId, path, false, parent.getId());
+			itemService.persistItemAfterCreate(siteId, path, parent.getId());
 			if (isPage) {
 				itemService.updateNewPageChildren(siteId, CS.removeEnd(path, SLASH_INDEX_FILE));
 			}
 		} else {
-			itemService.persistItemAfterWrite(siteId, path, false);
+			itemService.persistItemAfterWrite(siteId, path);
 		}
 		dependencyService.upsertDependencies(siteId, path);
 		dependencyService.validateDependencies(siteId, path);

--- a/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
@@ -144,52 +144,14 @@ public class ItemServiceInternalImpl implements ItemService {
 		generalLockService.lock(lockKey);
 		try {
 			User userObj = SecurityUtils.getCurrentUser();
-			boolean disabled = false;
-			String label = null;
-			String contentType = null;
-			String localeCode = null;
-			boolean savedAsDraft = false;
-			try {
-				var descriptor = contentRepository.getItem(siteId, path, false);
-				String disabledStr = descriptor.queryDescriptorValue(DISABLED);
-				disabled = Boolean.parseBoolean(disabledStr);
-				label = descriptor.queryDescriptorValue(INTERNAL_NAME_XPATH);
-				contentType = descriptor.queryDescriptorValue(CONTENT_TYPE);
-				localeCode = descriptor.queryDescriptorValue(LOCALE_CODE);
-				savedAsDraft = Boolean.parseBoolean(descriptor.queryDescriptorValue(SAVED_AS_DRAFT));
-			} catch (XmlFileParseException e) {
-				logger.debug("Error getting content descriptor for path: '{}'", path, e);
-				// If page, component, or other descriptor file, it must be a valid xml file
-				if (underDescriptorRoot(path)) {
-					throw new ServiceLayerException("Error getting content descriptor for path: " + path, e);
-				}
-			}
-			if (StringUtils.isEmpty(label)) {
-				label = FilenameUtils.getName(path);
-			}
-			Item item = instantiateItem(siteId, path)
-					.withPreviewUrl(getBrowserUrl(siteId, path))
-					.withCreatedBy(userObj.getId())
-					.withCreatedOn(DateUtils.getCurrentTime())
-					.withLastModifiedBy(userObj.getId())
-					.withLastModifiedOn(DateUtils.getCurrentTime())
-					.withLabel(label)
-					.withSystemType(getContentTypeClass(servicesConfig, studioConfiguration, siteId, path))
-					.withContentTypeId(contentType)
-					.withMimeType(StudioUtils.getMimeType(path))
-					.withLocaleCode(localeCode)
-					.withSize(contentRepository.getContentSize(siteId, path))
-					.withParentId(parentId)
-					.withSavedAsDraft(savedAsDraft)
-					.build();
+			Item item = buildItem(siteId, path, userObj);
+
+			item.setParentId(parentId);
+			item.setCreatedBy(userObj.getId());
+			item.setCreatedOn(DateUtils.getCurrentTime());
 
 			item.setLockedBy(userObj.getId());
-			item.setState(ItemState.savedAndNotClosed(item.getState()));
-
-			if (disabled) {
-				item.setState(item.getState() | ItemState.DISABLED.value);
-			}
-			retryingDatabaseOperationFacade.retry(() -> itemDao.upsertEntry(item));
+			upsertEntry(item);
 		} finally {
 			generalLockService.unlock(lockKey);
 		}
@@ -199,6 +161,21 @@ public class ItemServiceInternalImpl implements ItemService {
 	public void persistItemAfterWrite(String siteId, String path)
 		throws ServiceLayerException, AuthenticationException {
 		User userObj = SecurityUtils.getCurrentUser();
+		Item item = buildItem(siteId, path, userObj);
+		upsertEntry(item);
+	}
+
+	/**
+	 * Instantiates an Item with current timestamps and user info, as well as metadata
+	 * from the xml.
+	 *
+	 * @param siteId the site id
+	 * @param path   the item path
+	 * @return the Item
+	 * @throws AuthenticationException if there is an error getting the current user
+	 * @throws ServiceLayerException   if there is an error getting the content descriptor for the item
+	 */
+	protected Item buildItem(String siteId, String path, User userObj) throws AuthenticationException, ServiceLayerException {
 		boolean disabled = false;
 		String label = null;
 		String contentType = null;
@@ -223,26 +200,25 @@ public class ItemServiceInternalImpl implements ItemService {
 			label = FilenameUtils.getName(path);
 		}
 		Item item = instantiateItem(siteId, path)
-			.withPreviewUrl(getBrowserUrl(siteId, path))
-			.withLastModifiedBy(userObj.getId())
-			.withLastModifiedOn(DateUtils.getCurrentTime())
-			.withLabel(label)
-			.withSystemType(getContentTypeClass(servicesConfig, studioConfiguration, siteId, path))
-			.withContentTypeId(contentType)
-			.withMimeType(StudioUtils.getMimeType(path))
-			.withLocaleCode(localeCode)
-			.withSize(contentRepository.getContentSize(siteId, path))
-			.withSavedAsDraft(savedAsDraft)
-			.build();
+				.withPreviewUrl(getBrowserUrl(siteId, path))
+				.withLastModifiedBy(userObj.getId())
+				.withLastModifiedOn(DateUtils.getCurrentTime())
+				.withLabel(label)
+				.withSystemType(getContentTypeClass(servicesConfig, studioConfiguration, siteId, path))
+				.withContentTypeId(contentType)
+				.withMimeType(StudioUtils.getMimeType(path))
+				.withLocaleCode(localeCode)
+				.withSize(contentRepository.getContentSize(siteId, path))
+				.withSavedAsDraft(savedAsDraft)
+				.build();
 
 		item.setState(ItemState.savedAndNotClosed(item.getState()));
-
 		if (disabled) {
 			item.setState(item.getState() | ItemState.DISABLED.value);
 		} else {
 			item.setState(item.getState() & ~ItemState.DISABLED.value);
 		}
-		upsertEntry(item);
+		return item;
 	}
 
 	@Override

--- a/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
@@ -61,6 +61,7 @@ public class ItemServiceInternalImpl implements ItemService {
 	public final static String CONTENT_TYPE = "/*[1]/content-type";
 	public final static String DISABLED = "/*[1]/disabled";
 	public final static String LOCALE_CODE = "/*[1]/locale-code";
+	public final static String SAVED_AS_DRAFT = "/*[1]/savedAsDraft";
 
 	private UserService userService;
 	private SiteDAO siteDao;
@@ -137,8 +138,7 @@ public class ItemServiceInternalImpl implements ItemService {
 	}
 
 	@Override
-	public void persistItemAfterCreate(String siteId, String path,
-									   boolean unlock, Long parentId)
+	public void persistItemAfterCreate(String siteId, String path, Long parentId)
 			throws ServiceLayerException, AuthenticationException {
 		String lockKey = "persistItemAfterCreate:" + siteId;
 		generalLockService.lock(lockKey);
@@ -148,6 +148,7 @@ public class ItemServiceInternalImpl implements ItemService {
 			String label = null;
 			String contentType = null;
 			String localeCode = null;
+			boolean savedAsDraft = false;
 			try {
 				var descriptor = contentRepository.getItem(siteId, path, false);
 				String disabledStr = descriptor.queryDescriptorValue(DISABLED);
@@ -155,6 +156,7 @@ public class ItemServiceInternalImpl implements ItemService {
 				label = descriptor.queryDescriptorValue(INTERNAL_NAME_XPATH);
 				contentType = descriptor.queryDescriptorValue(CONTENT_TYPE);
 				localeCode = descriptor.queryDescriptorValue(LOCALE_CODE);
+				savedAsDraft = Boolean.parseBoolean(descriptor.queryDescriptorValue(SAVED_AS_DRAFT));
 			} catch (XmlFileParseException e) {
 				logger.debug("Error getting content descriptor for path: '{}'", path, e);
 				// If page, component, or other descriptor file, it must be a valid xml file
@@ -166,25 +168,24 @@ public class ItemServiceInternalImpl implements ItemService {
 				label = FilenameUtils.getName(path);
 			}
 			Item item = instantiateItem(siteId, path)
-				.withPreviewUrl(getBrowserUrl(siteId, path))
-				.withCreatedBy(userObj.getId())
-				.withCreatedOn(DateUtils.getCurrentTime())
-				.withLastModifiedBy(userObj.getId())
-				.withLastModifiedOn(DateUtils.getCurrentTime())
-				.withLabel(label)
-				.withSystemType(getContentTypeClass(servicesConfig, studioConfiguration, siteId, path))
-				.withContentTypeId(contentType)
-				.withMimeType(StudioUtils.getMimeType(path))
-				.withLocaleCode(localeCode)
-				.withSize(contentRepository.getContentSize(siteId, path))
-				.withParentId(parentId)
-				.build();
-			if (unlock) {
-				item.setState(ItemState.savedAndClosed(item.getState()));
-			} else {
-				item.setLockedBy(userObj.getId());
-				item.setState(ItemState.savedAndNotClosed(item.getState()));
-			}
+					.withPreviewUrl(getBrowserUrl(siteId, path))
+					.withCreatedBy(userObj.getId())
+					.withCreatedOn(DateUtils.getCurrentTime())
+					.withLastModifiedBy(userObj.getId())
+					.withLastModifiedOn(DateUtils.getCurrentTime())
+					.withLabel(label)
+					.withSystemType(getContentTypeClass(servicesConfig, studioConfiguration, siteId, path))
+					.withContentTypeId(contentType)
+					.withMimeType(StudioUtils.getMimeType(path))
+					.withLocaleCode(localeCode)
+					.withSize(contentRepository.getContentSize(siteId, path))
+					.withParentId(parentId)
+					.withSavedAsDraft(savedAsDraft)
+					.build();
+
+			item.setLockedBy(userObj.getId());
+			item.setState(ItemState.savedAndNotClosed(item.getState()));
+
 			if (disabled) {
 				item.setState(item.getState() | ItemState.DISABLED.value);
 			}
@@ -195,13 +196,14 @@ public class ItemServiceInternalImpl implements ItemService {
 	}
 
 	@Override
-	public void persistItemAfterWrite(String siteId, String path, boolean unlock)
+	public void persistItemAfterWrite(String siteId, String path)
 		throws ServiceLayerException, AuthenticationException {
 		User userObj = SecurityUtils.getCurrentUser();
 		boolean disabled = false;
 		String label = null;
 		String contentType = null;
 		String localeCode = null;
+		boolean savedAsDraft = false;
 		try {
 			var descriptor = contentRepository.getItem(siteId, path, false);
 			String disabledStr = descriptor.queryDescriptorValue(DISABLED);
@@ -209,6 +211,7 @@ public class ItemServiceInternalImpl implements ItemService {
 			label = descriptor.queryDescriptorValue(INTERNAL_NAME_XPATH);
 			contentType = descriptor.queryDescriptorValue(CONTENT_TYPE);
 			localeCode = descriptor.queryDescriptorValue(LOCALE_CODE);
+			savedAsDraft = Boolean.parseBoolean(descriptor.queryDescriptorValue(SAVED_AS_DRAFT));
 		} catch (XmlFileParseException e) {
 			logger.debug("Error getting content descriptor for path: '{}'", path, e);
 			// If page, component, or other descriptor file, it must be a valid xml file
@@ -229,12 +232,11 @@ public class ItemServiceInternalImpl implements ItemService {
 			.withMimeType(StudioUtils.getMimeType(path))
 			.withLocaleCode(localeCode)
 			.withSize(contentRepository.getContentSize(siteId, path))
+			.withSavedAsDraft(savedAsDraft)
 			.build();
-		if (unlock) {
-			item.setState(ItemState.savedAndClosed(item.getState()));
-		} else {
-			item.setState(ItemState.savedAndNotClosed(item.getState()));
-		}
+
+		item.setState(ItemState.savedAndNotClosed(item.getState()));
+
 		if (disabled) {
 			item.setState(item.getState() | ItemState.DISABLED.value);
 		} else {

--- a/src/main/java/org/craftercms/studio/impl/v2/sync/SyncFromRepositoryTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/sync/SyncFromRepositoryTask.java
@@ -550,6 +550,7 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 				}
 				result.contentTypeId = rootElement.valueOf(DOCUMENT_ELM_CONTENT_TYPE);
 				result.disabled = Boolean.parseBoolean(rootElement.valueOf(DOCUMENT_ELM_DISABLED));
+				result.savedAsDraft = Boolean.parseBoolean(rootElement.valueOf(DOCUMENT_ELM_SAVED_AS_DRAFT));
 			}
 		} catch (DocumentException e) {
 			logger.error("Failed to extract metadata from the XML site '{}' path '{}'",
@@ -599,6 +600,7 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 			.withLocaleCode(Locale.US.toString())
 			.withTranslationSourceId(null)
 			.withSize(contentRepository.getContentSize(site.getSiteId(), repoOperation.getPath()))
+			.withSavedAsDraft(metadata.savedAsDraft)
 			.build();
 		itemDao.upsertEntry(item);
 
@@ -636,7 +638,8 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 			repoOperation.getDateTime(), metadata.label, metadata.contentTypeId,
 				getContentTypeClass(servicesConfig, studioConfiguration, site.getSiteId(), repoOperation.getPath()),
 			StudioUtils.getMimeType(FilenameUtils.getName(repoOperation.getPath())),
-			contentRepository.getContentSize(site.getSiteId(), repoOperation.getPath()));
+			contentRepository.getContentSize(site.getSiteId(), repoOperation.getPath()),
+				metadata.savedAsDraft);
 
 		logger.trace("Extract dependencies from site '{}' path '{}' while processing batch update", site.getSiteId(), repoOperation.getPath());
 		DependencyUtils.updateDependencies(site.getSiteId(), repoOperation.getPath(), null,
@@ -658,7 +661,7 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 							 Set<String> allAncestors) throws SiteNotFoundException, ContentNotFoundException {
 		ItemMetadata metadata = getItemMetadata(site.getSiteId(), repoOperation.getMoveToPath());
 		processAncestors(itemDao, site.getSiteId(), repoOperation.getMoveToPath(), user.getId(),
-			repoOperation.getDateTime(), allAncestors);
+				repoOperation.getDateTime(), allAncestors);
 		long onStateBitMap = SAVE_AND_CLOSE_ON_MASK;
 		long offStateBitmap = SAVE_AND_CLOSE_OFF_MASK;
 		if (metadata.disabled) {
@@ -667,18 +670,19 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 			offStateBitmap = offStateBitmap | DISABLED.value;
 		}
 		if (!ArrayUtils.contains(IGNORE_FILES, FilenameUtils.getName(repoOperation.getPath())) &&
-			!ArrayUtils.contains(IGNORE_FILES, FilenameUtils.getName(repoOperation.getMoveToPath()))) {
+				!ArrayUtils.contains(IGNORE_FILES, FilenameUtils.getName(repoOperation.getMoveToPath()))) {
 			itemDao.moveItemForSyncTask(site.getSiteId(), repoOperation.getPath(), repoOperation.getMoveToPath(), onStateBitMap, offStateBitmap);
 
 			updateItemRow(itemDao, site.getId(),
-				repoOperation.getPath(), metadata.previewUrl, onStateBitMap, offStateBitmap, user.getId(),
-				repoOperation.getDateTime(), metadata.label, metadata.contentTypeId,
+					repoOperation.getPath(), metadata.previewUrl, onStateBitMap, offStateBitmap, user.getId(),
+					repoOperation.getDateTime(), metadata.label, metadata.contentTypeId,
 					getContentTypeClass(servicesConfig, studioConfiguration, site.getSiteId(), repoOperation.getMoveToPath()),
-				StudioUtils.getMimeType(FilenameUtils.getName(repoOperation.getPath())),
-				contentRepository.getContentSize(site.getSiteId(), repoOperation.getPath()));
+					StudioUtils.getMimeType(FilenameUtils.getName(repoOperation.getPath())),
+					contentRepository.getContentSize(site.getSiteId(), repoOperation.getPath()),
+					metadata.savedAsDraft);
 
 			DependencyUtils.updateDependencies(site.getSiteId(), repoOperation.getMoveToPath(),
-				repoOperation.getPath(), dependencyServiceInternal, dependencyDao, sqlSession);
+					repoOperation.getPath(), dependencyServiceInternal, dependencyDao, sqlSession);
 		}
 		invalidateConfigurationCacheIfRequired(site.getSiteId(), repoOperation.getMoveToPath());
 	}
@@ -702,11 +706,12 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 	private void updateItemRow(ItemDAO itemDao, long siteId, String path, String previewUrl, long onStatesBitMap,
 									   long offStatesBitMap, Long lastModifiedBy, ZonedDateTime lastModifiedOn,
 									   String label, String contentTypeId, String systemType, String mimeType,
-									   Long size) {
+									   Long size, boolean savedAsDraft) {
 		Timestamp sqlTsLastModified = new Timestamp(lastModifiedOn.toInstant().toEpochMilli());
 		String fileName = FilenameUtils.getName(path);
 		boolean ignored = org.apache.commons.lang3.ArrayUtils.contains(IGNORE_FILES, fileName);
-		itemDao.updateItemForSyncTask(siteId, path, previewUrl, onStatesBitMap, offStatesBitMap, lastModifiedBy, sqlTsLastModified.toString(), label, contentTypeId, systemType, mimeType, size, ignored);
+		itemDao.updateItemForSyncTask(siteId, path, previewUrl, onStatesBitMap, offStatesBitMap,
+				lastModifiedBy, sqlTsLastModified.toString(), label, contentTypeId, systemType, mimeType, size, ignored, savedAsDraft);
 	}
 
 	/**
@@ -781,6 +786,7 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 					.withLocaleCode(Locale.US.toString())
 					.withTranslationSourceId(null)
 					.withSize(0L)
+					.withSavedAsDraft(false)
 					.build();
 				itemDao.upsertEntry(item);
 				allAncestors.add(currentPath);
@@ -801,6 +807,7 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 		String label;
 		String contentTypeId = EMPTY;
 		boolean disabled = false;
+		boolean savedAsDraft = false;
 
 		public ItemMetadata(final String path) {
 			label = FilenameUtils.getName(path);

--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -56,8 +56,8 @@ BEGIN
 	INSERT INTO dependency (id, site, source_path, target_path, type, valid)
 		SELECT null, siteId, d.source_path, d.target_path, d.type, d.valid FROM dependency d WHERE d.site = sourceSiteId;
 
-	INSERT INTO item (id, record_last_updated, site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by, last_modified_on, label, content_type_id, system_type, mime_type, locale_code, translation_source_id, size, parent_id, ignored)
-		SELECT null, i.record_last_updated, (SELECT id FROM site WHERE site_id = siteId AND deleted = 0), i.path, i.preview_url, i.state, i.locked_by, i.created_by, i.created_on, i.last_modified_by, i.last_modified_on, i.label, i.content_type_id, i.system_type, i.mime_type, i.locale_code, i.translation_source_id, i.size, i.parent_id, i.ignored FROM item i inner join site s ON i.site_id = s.id WHERE s.site_id = sourceSiteId;
+	INSERT INTO item (id, record_last_updated, site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by, last_modified_on, label, content_type_id, system_type, mime_type, locale_code, translation_source_id, size, parent_id, ignored, saved_as_draft)
+		SELECT null, i.record_last_updated, (SELECT id FROM site WHERE site_id = siteId AND deleted = 0), i.path, i.preview_url, i.state, i.locked_by, i.created_by, i.created_on, i.last_modified_by, i.last_modified_on, i.label, i.content_type_id, i.system_type, i.mime_type, i.locale_code, i.translation_source_id, i.size, i.parent_id, i.ignored, i.saved_as_draft FROM item i inner join site s ON i.site_id = s.id WHERE s.site_id = sourceSiteId;
 
 	SELECT id FROM site WHERE site_id = siteId AND deleted = 0 INTO @siteNumericId;
 
@@ -224,7 +224,7 @@ CREATE TABLE _meta (
 	PRIMARY KEY (`version`)
 ) ;
 
-INSERT INTO _meta (version, studio_id) VALUES ('5.0.0.15', UUID()) ;
+INSERT INTO _meta (version, studio_id) VALUES ('5.0.0.17', UUID()) ;
 
 CREATE TABLE IF NOT EXISTS `audit` (
 	`id`                        BIGINT(20)    NOT NULL AUTO_INCREMENT,
@@ -511,6 +511,7 @@ CREATE TABLE IF NOT EXISTS `item` (
   `size`                    BIGINT          NULL,
   `parent_id`               BIGINT          NULL,
   `ignored`                 INT             NOT NULL    DEFAULT 0,
+  `saved_as_draft`          BOOLEAN         NULL,
   PRIMARY KEY (`id`),
   FOREIGN KEY item_ix_created_by(`created_by`) REFERENCES `user` (`id`),
   FOREIGN KEY item_ix_last_modified_by(`last_modified_by`) REFERENCES `user` (`id`),

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.16-to-5.0.0.17.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.16-to-5.0.0.17.sql
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ALTER TABLE `item` ADD COLUMN IF NOT EXISTS `saved_as_draft` BOOLEAN ;
+
+UPDATE `item` SET `saved_as_draft` = FALSE
+	WHERE `system_type` = 'folder'
+ 		OR PATH NOT LIKE '/site/%' ;
+
+DROP PROCEDURE IF EXISTS duplicate_site ;
+
+CREATE PROCEDURE duplicate_site(IN sourceSiteId VARCHAR(50),
+									IN siteId VARCHAR(2000),
+									IN name VARCHAR(2000),
+									IN description VARCHAR(2000),
+									IN sandboxBranch VARCHAR(2000),
+									IN uuid VARCHAR(2000))
+BEGIN
+	INSERT INTO site (id, site_uuid, site_id, name, description, deleted, last_commit_id, system, publishing_enabled, publishing_status, sandbox_branch, published_repo_created, state)
+		SELECT null, uuid, siteId, name, description, s.deleted, s.last_commit_id, s.system, 1, 'ready', IFNULL(NULLIF(sandboxBranch, ''), 'master'), s.published_repo_created, 'INITIALIZING' FROM site s WHERE s.site_id = sourceSiteId AND s.deleted = 0;
+
+	INSERT INTO remote_repository (id, site_id, remote_name, remote_url, authentication_type, remote_username, remote_password, remote_token, remote_private_key)
+		SELECT null, siteId, r.remote_name, r.remote_url, r.authentication_type, r.remote_username, r.remote_password, r.remote_token, r.remote_private_key FROM remote_repository r WHERE r.site_id = sourceSiteId;
+
+	INSERT INTO dependency (id, site, source_path, target_path, type, valid)
+		SELECT null, siteId, d.source_path, d.target_path, d.type, d.valid FROM dependency d WHERE d.site = sourceSiteId;
+
+	INSERT INTO item (id, record_last_updated, site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by, last_modified_on, label, content_type_id, system_type, mime_type, locale_code, translation_source_id, size, parent_id, ignored, saved_as_draft)
+		SELECT null, i.record_last_updated, (SELECT id FROM site WHERE site_id = siteId AND deleted = 0), i.path, i.preview_url, i.state, i.locked_by, i.created_by, i.created_on, i.last_modified_by, i.last_modified_on, i.label, i.content_type_id, i.system_type, i.mime_type, i.locale_code, i.translation_source_id, i.size, i.parent_id, i.ignored, i.saved_as_draft FROM item i inner join site s ON i.site_id = s.id WHERE s.site_id = sourceSiteId;
+
+	SELECT id FROM site WHERE site_id = siteId AND deleted = 0 INTO @siteNumericId;
+
+	INSERT INTO navigation_order_sequence (folder_id, site, path, max_count)
+		SELECT UUID(), siteId, nos.path, nos.max_count FROM navigation_order_sequence nos WHERE nos.site = sourceSiteId;
+
+	SELECT id FROM site WHERE site_id = sourceSiteId AND deleted = 0 INTO @sourceSiteNumericId;
+
+	INSERT INTO item_target(item_id, target, previous_path, last_published_on, published_commit_id)
+	SELECT newItem.id, target, previous_path, last_published_on, published_commit_id
+	FROM item_target it
+		INNER JOIN item sourceItem ON sourceItem.id = it.item_id
+		INNER JOIN item newItem ON sourceItem.path = newItem.path
+	WHERE sourceItem.site_id = @sourceSiteNumericId
+	AND newItem.site_id = @siteNumericId;
+
+	INSERT INTO processed_commits (id, site_id, commit_id)
+		SELECT null, @siteNumericId, pc.commit_id
+		FROM processed_commits pc
+		WHERE site_id = @sourceSiteNumericId;
+
+	CALL populateItemParentId(@siteNumericId);
+END ;

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -606,6 +606,11 @@ pipelines:
                             -   src: repo-bootstrap/global/configuration/samples/sample-ui.xml
                                 dest: configuration/samples/sample-ui.xml
                         commitDetails: Update sample file for ui.xml
+            -   currentVersion: 5.0.0.16
+                nextVersion: 5.0.0.17
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/5.0.0.16-to-5.0.0.17.sql
 
     # Pipeline to upgrade site repositories
     site:

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -115,10 +115,10 @@
 	<insert id="upsertEntry" parameterType="org.craftercms.studio.api.v2.dal.Item">
 		INSERT INTO item (site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by,
 				  last_modified_on, label, content_type_id, system_type, mime_type, locale_code,
-				  translation_source_id, size, parent_id, ignored)
+				  translation_source_id, size, parent_id, ignored, saved_as_draft)
 		VALUES (#{siteId}, #{path}, #{previewUrl}, #{state}, #{lockedBy}, #{createdBy}, #{createdOn}, #{lastModifiedBy},
 			#{lastModifiedOn}, #{label}, #{contentTypeId}, #{systemType}, #{mimeType},
-			#{localeCode}, #{translationSourceId}, #{size}, #{parentId}, #{ignoredAsInt}) ON DUPLICATE KEY
+			#{localeCode}, #{translationSourceId}, #{size}, #{parentId}, #{ignoredAsInt}, #{savedAsDraft}) ON DUPLICATE KEY
 		UPDATE
 			site_id = #{siteId},
 			path = #{path},
@@ -135,7 +135,8 @@
 			translation_source_id = #{translationSourceId},
 			size = #{size},
 			parent_id = #{parentId},
-			ignored = #{ignoredAsInt}
+			ignored = #{ignoredAsInt},
+			saved_as_draft = #{savedAsDraft}
 	</insert>
 
 	<sql id="getChildrenByPathFilters">
@@ -372,12 +373,12 @@
 	<update id="copyItemInternal">
 		INSERT INTO item (site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by,
 				  last_modified_on, label, content_type_id, system_type, mime_type, locale_code,
-				  translation_source_id, size, parent_id, ignored)
+				  translation_source_id, size, parent_id, ignored, saved_as_draft)
 		SELECT s.id, #{newPath} AS path, IF(i.system_type = '${systemTypeFolder}', NULL, #{previewUrl}) AS preview_url,
 				CASE WHEN i.system_type = '${systemTypeFolder}' THEN 0 ELSE ${state} END,
 				null, ${userId}, NOW(), ${userId},
 				NOW(), IFNULL(#{label}, i.label) AS label, i.content_type_id, i.system_type, i.mime_type, i.locale_code,
-				i.translation_source_id, i.size, #{parentId}, i.ignored
+				i.translation_source_id, i.size, #{parentId}, i.ignored, i.saved_as_draft
 		FROM item i INNER JOIN site s ON i.site_id = s.id
 		WHERE s.site_id = #{siteId}
 		AND s.deleted = 0
@@ -684,7 +685,8 @@
 			mime_type = #{mimeType},
 			size = #{size},
 			locked_by = NULL,
-			ignored = #{ignored}
+			ignored = #{ignored},
+			saved_as_draft = #{savedAsDraft}
 		WHERE
 			site_id = #{siteId}
 			AND path = #{path};

--- a/src/test/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImplTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImplTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.studio.impl.v2.service.item.internal;
+
+import org.craftercms.core.service.Item;
+import org.craftercms.studio.api.v1.exception.ServiceLayerException;
+import org.craftercms.studio.api.v1.exception.security.AuthenticationException;
+import org.craftercms.studio.api.v1.service.GeneralLockService;
+import org.craftercms.studio.api.v2.dal.ItemDAO;
+import org.craftercms.studio.api.v2.dal.RetryingDatabaseOperationFacade;
+import org.craftercms.studio.api.v2.dal.Site;
+import org.craftercms.studio.api.v2.dal.SiteDAO;
+import org.craftercms.studio.api.v2.repository.GitContentRepository;
+import org.craftercms.studio.impl.v1.util.ContentUtils;
+import org.craftercms.studio.impl.v2.utils.security.SecurityUtils;
+import org.craftercms.studio.model.AuthenticatedUser;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ItemServiceInternalImplTest {
+
+	private static final String SITE_ID = "sample-site";
+	private static final String PATH = "/sample/path";
+	private static final Long PARENT_ID = 123L;
+
+	@Mock
+	private GitContentRepository contentRepository;
+	@Mock
+	private GeneralLockService generalLockService;
+	@Mock
+	private SiteDAO siteDAO;
+	@Mock
+	private ItemDAO itemDAO;
+	@Mock
+	private RetryingDatabaseOperationFacade retryingDatabaseOperationFacade;
+	@Spy
+	@InjectMocks
+	private ItemServiceInternalImpl service;
+
+	@Before
+	public void setUp() throws ServiceLayerException {
+		doNothing().when(retryingDatabaseOperationFacade).retry(any(Runnable.class));
+
+		Site mockSite = mock(Site.class);
+		when(mockSite.getId()).thenReturn(123L);
+		when(siteDAO.getSite(SITE_ID)).thenReturn(mockSite);
+		when(itemDAO.getItemByPath(123L, PATH, false)).thenReturn(mock(org.craftercms.studio.api.v2.dal.Item.class));
+
+		doReturn("browser/url").when(service).getBrowserUrl(SITE_ID, PATH);
+	}
+
+	@Test
+	public void testSavedAsDraftTrue() throws AuthenticationException, ServiceLayerException {
+		testSavedAsDraft("true", true);
+	}
+
+	@Test
+	public void testSavedAsDraftFalse() throws AuthenticationException, ServiceLayerException {
+		testSavedAsDraft("false", false);
+	}
+
+	@Test
+	public void testSavedAsDraftInvalidValue() throws AuthenticationException, ServiceLayerException {
+		testSavedAsDraft("invalid", false);
+	}
+
+	private void testSavedAsDraft(String valueInXml, boolean expected) throws AuthenticationException, ServiceLayerException {
+		Item mockItem = mock(Item.class);
+		when(mockItem.queryDescriptorValue(ItemServiceInternalImpl.SAVED_AS_DRAFT)).thenReturn(valueInXml);
+		when(contentRepository.getItem(SITE_ID, PATH, false)).thenReturn(mockItem);
+
+		try (MockedStatic<SecurityUtils> secUtilsMock = mockStatic(SecurityUtils.class);
+			 MockedStatic<ContentUtils> contentUtilsMock = mockStatic(ContentUtils.class)) {
+			AuthenticatedUser user = mock(AuthenticatedUser.class);
+			secUtilsMock.when(SecurityUtils::getCurrentUser).thenReturn(user);
+
+			contentUtilsMock.when(() -> ContentUtils.getContentTypeClass(any(), any(), any(), any())).thenReturn("the type");
+			service.persistItemAfterCreate(SITE_ID, PATH, PARENT_ID);
+			verify(service).upsertEntry(argThat(item -> item.getSavedAsDraft() == expected));
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8666
Add savedAsDraft to ContentItem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content items now support saved-as-draft status, visible in item metadata and preserved during repository sync and item operations.
* **Chores**
  * Database schema updated to store draft status and includes an upgrade script and pipeline step to migrate existing items.
* **Tests**
  * Added unit tests validating saved-as-draft behavior and mapping from content descriptors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/craftercms/studio/pull/3924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->